### PR TITLE
Adds workaround for free-form maps with propper typespec

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -175,7 +175,8 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
                         "Map",
                         "Tuple",
                         "PID",
-                        "DateTime"
+                        "DateTime",
+                        "map()" // This is a workaround, since the DefaultCodeGen uses our elixir TypeSpec datetype to evaluate the primitive
                 )
         );
 
@@ -510,7 +511,7 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
         } else if (ModelUtils.isDateTimeSchema(p)) {
             return "DateTime.t";
         } else if (ModelUtils.isObjectSchema(p)) {
-            return super.getTypeDeclaration(p) + ".t";
+            return "map()";
         } else if (ModelUtils.isIntegerSchema(p)) {
             return "integer()";
         } else if (ModelUtils.isNumberSchema(p)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -168,6 +168,7 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
                 Arrays.asList(
                         "Integer",
                         "Float",
+                        "Decimal",
                         "Boolean",
                         "String",
                         "List",
@@ -520,9 +521,8 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
             return "String.t";
         } else if (ModelUtils.isBooleanSchema(p)) {
             return "boolean()";
-        } else if (!StringUtils.isEmpty(p.get$ref())) { // model
-            // How to map it?
-            return super.getTypeDeclaration(p);
+        } else if (!StringUtils.isEmpty(p.get$ref())) {
+            return this.moduleName + ".Model." + super.getTypeDeclaration(p) + ".t";
         } else if (ModelUtils.isFileSchema(p)) {
             return "String.t";
         } else if (ModelUtils.isStringSchema(p)) {
@@ -593,12 +593,12 @@ public class ElixirClientCodegen extends DefaultCodegen implements CodegenConfig
             this.isDefinedDefault = (this.code.equals("0") || this.code.equals("default"));
         }
 
-        public String codeMappingKey(){
-            if(this.isDefinedDefault) {
+        public String codeMappingKey() {
+            if (this.isDefinedDefault) {
                 return ":default";
             }
 
-            if(code.matches("^\\d{3}$")){
+            if (code.matches("^\\d{3}$")) {
                 return code;
             }
 

--- a/modules/openapi-generator/src/main/resources/elixir/api.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/api.mustache
@@ -35,8 +35,8 @@ defmodule {{moduleName}}.Api.{{classname}} do
 {{/optionalParams}}
   ## Returns
 
-  {:ok, {{#isArray}}[%{{&returnBaseType}}{}, ...]{{/isArray}}{{#isMap}}%{}{{/isMap}}{{^returnType}}%{}{{/returnType}}{{#returnSimpleType}}%{{#returnType}}{{#isMap}}{{/isMap}}{{{moduleName}}}.Model.{{{returnType}}}{{/returnType}}{}{{/returnSimpleType}}} on success
-  {:error, info} on failure
+  {:ok, {{#isArray}}[%{{&returnBaseType}}{}, ...]{{/isArray}}{{#isMap}}%{}{{/isMap}}{{^returnType}}nil{{/returnType}}{{#returnSimpleType}}{{#returnType}}{{#isMap}}{{/isMap}}{{{returnType}}}{{/returnType}}{{/returnSimpleType}}} on success
+  {:error, Tesla.Env.t} on failure
   """
   {{{typespec}}}
   def {{{operationId}}}(connection, {{#requiredParams}}{{#underscored}}{{{paramName}}}{{/underscored}}, {{/requiredParams}}{{^hasOptionalParams}}_{{/hasOptionalParams}}opts \\ []) do

--- a/modules/openapi-generator/src/main/resources/elixir/model.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/model.mustache
@@ -23,8 +23,8 @@ defimpl Poison.Decoder, for: {{&moduleName}}.Model.{{&classname}} do
     value
     {{#vars}}
     {{^isPrimitiveType}}
-    {{#datatype}}|> deserialize(:"{{&baseName}}", {{#isArray}}:list, {{&moduleName}}.Model.{{{items.datatype}}}{{/isArray}}{{#isMap}}:map, {{&moduleName}}.Model.{{{items.datatype}}}{{/isMap}}{{#isDate}}:date, nil{{/isDate}}{{#isDateTime}}:date, nil{{/isDateTime}}{{^isDate}}{{^isDateTime}}{{^isMap}}{{^isArray}}:struct, {{moduleName}}.Model.{{dataType}}{{/isArray}}{{/isMap}}{{/isDateTime}}{{/isDate}}, options)
-    {{/datatype}}
+    {{#baseType}}|> deserialize(:"{{&baseName}}", {{#isArray}}:list, {{&moduleName}}.Model.{{{items.baseType}}}{{/isArray}}{{#isMap}}:map, {{&moduleName}}.Model.{{{items.baseType}}}{{/isMap}}{{#isDate}}:date, nil{{/isDate}}{{#isDateTime}}:date, nil{{/isDateTime}}{{^isDate}}{{^isDateTime}}{{^isMap}}{{^isArray}}:struct, {{moduleName}}.Model.{{baseType}}{{/isArray}}{{/isMap}}{{/isDateTime}}{{/isDate}}, options)
+    {{/baseType}}
     {{/isPrimitiveType}}
     {{/vars}}
 {{/hasComplexVars}}

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/another_fake.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/another_fake.ex
@@ -22,8 +22,8 @@ defmodule OpenapiPetstore.Api.AnotherFake do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %OpenapiPetstore.Model.Client{}} on success
-  {:error, info} on failure
+  {:ok, OpenapiPetstore.Model.Client.t} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec call_123_test_special_tags(Tesla.Env.client, OpenapiPetstore.Model.Client.t, keyword()) :: {:ok, OpenapiPetstore.Model.Client.t} | {:error, Tesla.Env.t}
   def call_123_test_special_tags(connection, body, _opts \\ []) do

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
@@ -22,8 +22,8 @@ defmodule OpenapiPetstore.Api.Fake do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec create_xml_item(Tesla.Env.client, OpenapiPetstore.Model.XmlItem.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def create_xml_item(connection, xml_item, _opts \\ []) do
@@ -48,8 +48,8 @@ defmodule OpenapiPetstore.Api.Fake do
     - :body (boolean()): Input boolean as post body
   ## Returns
 
-  {:ok, %OpenapiPetstore.Model.boolean(){}} on success
-  {:error, info} on failure
+  {:ok, boolean()} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec fake_outer_boolean_serialize(Tesla.Env.client, keyword()) :: {:ok, Boolean.t} | {:error, Tesla.Env.t}
   def fake_outer_boolean_serialize(connection, opts \\ []) do
@@ -77,8 +77,8 @@ defmodule OpenapiPetstore.Api.Fake do
     - :body (OuterComposite): Input composite as post body
   ## Returns
 
-  {:ok, %OpenapiPetstore.Model.OuterComposite{}} on success
-  {:error, info} on failure
+  {:ok, OpenapiPetstore.Model.OuterComposite.t} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec fake_outer_composite_serialize(Tesla.Env.client, keyword()) :: {:ok, OpenapiPetstore.Model.OuterComposite.t} | {:error, Tesla.Env.t}
   def fake_outer_composite_serialize(connection, opts \\ []) do
@@ -106,8 +106,8 @@ defmodule OpenapiPetstore.Api.Fake do
     - :body (float()): Input number as post body
   ## Returns
 
-  {:ok, %OpenapiPetstore.Model.float(){}} on success
-  {:error, info} on failure
+  {:ok, float()} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec fake_outer_number_serialize(Tesla.Env.client, keyword()) :: {:ok, Float.t} | {:error, Tesla.Env.t}
   def fake_outer_number_serialize(connection, opts \\ []) do
@@ -135,8 +135,8 @@ defmodule OpenapiPetstore.Api.Fake do
     - :body (String.t): Input string as post body
   ## Returns
 
-  {:ok, %OpenapiPetstore.Model.String.t{}} on success
-  {:error, info} on failure
+  {:ok, String.t} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec fake_outer_string_serialize(Tesla.Env.client, keyword()) :: {:ok, String.t} | {:error, Tesla.Env.t}
   def fake_outer_string_serialize(connection, opts \\ []) do
@@ -164,8 +164,8 @@ defmodule OpenapiPetstore.Api.Fake do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec test_body_with_file_schema(Tesla.Env.client, OpenapiPetstore.Model.FileSchemaTestClass.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_body_with_file_schema(connection, body, _opts \\ []) do
@@ -190,8 +190,8 @@ defmodule OpenapiPetstore.Api.Fake do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec test_body_with_query_params(Tesla.Env.client, String.t, OpenapiPetstore.Model.User.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_body_with_query_params(connection, query, body, _opts \\ []) do
@@ -218,8 +218,8 @@ defmodule OpenapiPetstore.Api.Fake do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %OpenapiPetstore.Model.Client{}} on success
-  {:error, info} on failure
+  {:ok, OpenapiPetstore.Model.Client.t} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec test_client_model(Tesla.Env.client, OpenapiPetstore.Model.Client.t, keyword()) :: {:ok, OpenapiPetstore.Model.Client.t} | {:error, Tesla.Env.t}
   def test_client_model(connection, body, _opts \\ []) do
@@ -258,8 +258,8 @@ defmodule OpenapiPetstore.Api.Fake do
     - :callback (String.t): None
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec test_endpoint_parameters(Tesla.Env.client, float(), float(), String.t, binary(), keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_endpoint_parameters(connection, number, double, pattern_without_delimiter, byte, opts \\ []) do
@@ -309,8 +309,8 @@ defmodule OpenapiPetstore.Api.Fake do
     - :enum_form_string (String.t): Form parameter enum test (string)
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec test_enum_parameters(Tesla.Env.client, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_enum_parameters(connection, opts \\ []) do
@@ -352,8 +352,8 @@ defmodule OpenapiPetstore.Api.Fake do
     - :int64_group (integer()): Integer in group parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec test_group_parameters(Tesla.Env.client, integer(), boolean(), integer(), keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_group_parameters(connection, required_string_group, required_boolean_group, required_int64_group, opts \\ []) do
@@ -386,8 +386,8 @@ defmodule OpenapiPetstore.Api.Fake do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec test_inline_additional_properties(Tesla.Env.client, %{optional(String.t) => String.t}, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_inline_additional_properties(connection, param, _opts \\ []) do
@@ -413,8 +413,8 @@ defmodule OpenapiPetstore.Api.Fake do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec test_json_form_data(Tesla.Env.client, String.t, String.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_json_form_data(connection, param, param2, _opts \\ []) do
@@ -444,8 +444,8 @@ defmodule OpenapiPetstore.Api.Fake do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec test_query_parameter_collection_format(Tesla.Env.client, list(String.t), list(String.t), list(String.t), list(String.t), list(String.t), keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_query_parameter_collection_format(connection, pipe, ioutil, http, url, context, _opts \\ []) do

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/fake_classname_tags123.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/fake_classname_tags123.ex
@@ -22,8 +22,8 @@ defmodule OpenapiPetstore.Api.FakeClassnameTags123 do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %OpenapiPetstore.Model.Client{}} on success
-  {:error, info} on failure
+  {:ok, OpenapiPetstore.Model.Client.t} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec test_classname(Tesla.Env.client, OpenapiPetstore.Model.Client.t, keyword()) :: {:ok, OpenapiPetstore.Model.Client.t} | {:error, Tesla.Env.t}
   def test_classname(connection, body, _opts \\ []) do

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/pet.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/pet.ex
@@ -21,8 +21,8 @@ defmodule OpenapiPetstore.Api.Pet do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec add_pet(Tesla.Env.client, OpenapiPetstore.Model.Pet.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def add_pet(connection, body, _opts \\ []) do
@@ -49,8 +49,8 @@ defmodule OpenapiPetstore.Api.Pet do
     - :api_key (String.t): 
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec delete_pet(Tesla.Env.client, integer(), keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def delete_pet(connection, pet_id, opts \\ []) do
@@ -81,7 +81,7 @@ defmodule OpenapiPetstore.Api.Pet do
   ## Returns
 
   {:ok, [%Pet{}, ...]} on success
-  {:error, info} on failure
+  {:error, Tesla.Env.t} on failure
   """
   @spec find_pets_by_status(Tesla.Env.client, list(String.t), keyword()) :: {:ok, nil} | {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
   def find_pets_by_status(connection, status, _opts \\ []) do
@@ -109,7 +109,7 @@ defmodule OpenapiPetstore.Api.Pet do
   ## Returns
 
   {:ok, [%Pet{}, ...]} on success
-  {:error, info} on failure
+  {:error, Tesla.Env.t} on failure
   """
   @spec find_pets_by_tags(Tesla.Env.client, list(String.t), keyword()) :: {:ok, nil} | {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
   def find_pets_by_tags(connection, tags, _opts \\ []) do
@@ -136,8 +136,8 @@ defmodule OpenapiPetstore.Api.Pet do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %OpenapiPetstore.Model.Pet{}} on success
-  {:error, info} on failure
+  {:ok, OpenapiPetstore.Model.Pet.t} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec get_pet_by_id(Tesla.Env.client, integer(), keyword()) :: {:ok, nil} | {:ok, OpenapiPetstore.Model.Pet.t} | {:error, Tesla.Env.t}
   def get_pet_by_id(connection, pet_id, _opts \\ []) do
@@ -163,8 +163,8 @@ defmodule OpenapiPetstore.Api.Pet do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec update_pet(Tesla.Env.client, OpenapiPetstore.Model.Pet.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def update_pet(connection, body, _opts \\ []) do
@@ -194,8 +194,8 @@ defmodule OpenapiPetstore.Api.Pet do
     - :status (String.t): Updated status of the pet
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec update_pet_with_form(Tesla.Env.client, integer(), keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def update_pet_with_form(connection, pet_id, opts \\ []) do
@@ -226,8 +226,8 @@ defmodule OpenapiPetstore.Api.Pet do
     - :file (String.t): file to upload
   ## Returns
 
-  {:ok, %OpenapiPetstore.Model.ApiResponse{}} on success
-  {:error, info} on failure
+  {:ok, OpenapiPetstore.Model.ApiResponse.t} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec upload_file(Tesla.Env.client, integer(), keyword()) :: {:ok, OpenapiPetstore.Model.ApiResponse.t} | {:error, Tesla.Env.t}
   def upload_file(connection, pet_id, opts \\ []) do
@@ -258,8 +258,8 @@ defmodule OpenapiPetstore.Api.Pet do
     - :additional_metadata (String.t): Additional data to pass to server
   ## Returns
 
-  {:ok, %OpenapiPetstore.Model.ApiResponse{}} on success
-  {:error, info} on failure
+  {:ok, OpenapiPetstore.Model.ApiResponse.t} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec upload_file_with_required_file(Tesla.Env.client, integer(), String.t, keyword()) :: {:ok, OpenapiPetstore.Model.ApiResponse.t} | {:error, Tesla.Env.t}
   def upload_file_with_required_file(connection, pet_id, required_file, opts \\ []) do

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/store.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/store.ex
@@ -22,8 +22,8 @@ defmodule OpenapiPetstore.Api.Store do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec delete_order(Tesla.Env.client, String.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def delete_order(connection, order_id, _opts \\ []) do
@@ -49,7 +49,7 @@ defmodule OpenapiPetstore.Api.Store do
   ## Returns
 
   {:ok, %{}} on success
-  {:error, info} on failure
+  {:error, Tesla.Env.t} on failure
   """
   @spec get_inventory(Tesla.Env.client, keyword()) :: {:ok, map()} | {:error, Tesla.Env.t}
   def get_inventory(connection, _opts \\ []) do
@@ -74,8 +74,8 @@ defmodule OpenapiPetstore.Api.Store do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %OpenapiPetstore.Model.Order{}} on success
-  {:error, info} on failure
+  {:ok, OpenapiPetstore.Model.Order.t} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec get_order_by_id(Tesla.Env.client, integer(), keyword()) :: {:ok, nil} | {:ok, OpenapiPetstore.Model.Order.t} | {:error, Tesla.Env.t}
   def get_order_by_id(connection, order_id, _opts \\ []) do
@@ -101,8 +101,8 @@ defmodule OpenapiPetstore.Api.Store do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %OpenapiPetstore.Model.Order{}} on success
-  {:error, info} on failure
+  {:ok, OpenapiPetstore.Model.Order.t} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec place_order(Tesla.Env.client, OpenapiPetstore.Model.Order.t, keyword()) :: {:ok, nil} | {:ok, OpenapiPetstore.Model.Order.t} | {:error, Tesla.Env.t}
   def place_order(connection, body, _opts \\ []) do

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/user.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/user.ex
@@ -22,8 +22,8 @@ defmodule OpenapiPetstore.Api.User do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec create_user(Tesla.Env.client, OpenapiPetstore.Model.User.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def create_user(connection, body, _opts \\ []) do
@@ -44,12 +44,12 @@ defmodule OpenapiPetstore.Api.User do
   ## Parameters
 
   - connection (OpenapiPetstore.Connection): Connection to server
-  - body ([User]): List of user object
+  - body ([OpenapiPetstore.Model.User.t]): List of user object
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec create_users_with_array_input(Tesla.Env.client, list(OpenapiPetstore.Model.User.t), keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def create_users_with_array_input(connection, body, _opts \\ []) do
@@ -70,12 +70,12 @@ defmodule OpenapiPetstore.Api.User do
   ## Parameters
 
   - connection (OpenapiPetstore.Connection): Connection to server
-  - body ([User]): List of user object
+  - body ([OpenapiPetstore.Model.User.t]): List of user object
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec create_users_with_list_input(Tesla.Env.client, list(OpenapiPetstore.Model.User.t), keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def create_users_with_list_input(connection, body, _opts \\ []) do
@@ -101,8 +101,8 @@ defmodule OpenapiPetstore.Api.User do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec delete_user(Tesla.Env.client, String.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def delete_user(connection, username, _opts \\ []) do
@@ -127,8 +127,8 @@ defmodule OpenapiPetstore.Api.User do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %OpenapiPetstore.Model.User{}} on success
-  {:error, info} on failure
+  {:ok, OpenapiPetstore.Model.User.t} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec get_user_by_name(Tesla.Env.client, String.t, keyword()) :: {:ok, nil} | {:ok, OpenapiPetstore.Model.User.t} | {:error, Tesla.Env.t}
   def get_user_by_name(connection, username, _opts \\ []) do
@@ -155,8 +155,8 @@ defmodule OpenapiPetstore.Api.User do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %OpenapiPetstore.Model.String.t{}} on success
-  {:error, info} on failure
+  {:ok, String.t} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec login_user(Tesla.Env.client, String.t, String.t, keyword()) :: {:ok, nil} | {:ok, String.t} | {:error, Tesla.Env.t}
   def login_user(connection, username, password, _opts \\ []) do
@@ -182,8 +182,8 @@ defmodule OpenapiPetstore.Api.User do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec logout_user(Tesla.Env.client, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def logout_user(connection, _opts \\ []) do
@@ -209,8 +209,8 @@ defmodule OpenapiPetstore.Api.User do
   - opts (KeywordList): [optional] Optional parameters
   ## Returns
 
-  {:ok, %{}} on success
-  {:error, info} on failure
+  {:ok, nil} on success
+  {:error, Tesla.Env.t} on failure
   """
   @spec update_user(Tesla.Env.client, String.t, OpenapiPetstore.Model.User.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def update_user(connection, username, body, _opts \\ []) do

--- a/samples/client/petstore/elixir/lib/openapi_petstore/model/additional_properties_class.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/model/additional_properties_class.ex
@@ -28,22 +28,18 @@ defmodule OpenapiPetstore.Model.AdditionalPropertiesClass do
     :"map_integer" => %{optional(String.t) => integer()} | nil,
     :"map_boolean" => %{optional(String.t) => boolean()} | nil,
     :"map_array_integer" => %{optional(String.t) => [integer()]} | nil,
-    :"map_array_anytype" => %{optional(String.t) => [Map.t]} | nil,
+    :"map_array_anytype" => %{optional(String.t) => [map()]} | nil,
     :"map_map_string" => %{optional(String.t) => %{optional(String.t) => String.t}} | nil,
-    :"map_map_anytype" => %{optional(String.t) => %{optional(String.t) => Map.t}} | nil,
-    :"anytype_1" => Map.t | nil,
-    :"anytype_2" => Map.t | nil,
-    :"anytype_3" => Map.t | nil
+    :"map_map_anytype" => %{optional(String.t) => %{optional(String.t) => map()}} | nil,
+    :"anytype_1" => map() | nil,
+    :"anytype_2" => map() | nil,
+    :"anytype_3" => map() | nil
   }
 end
 
 defimpl Poison.Decoder, for: OpenapiPetstore.Model.AdditionalPropertiesClass do
-  import OpenapiPetstore.Deserializer
-  def decode(value, options) do
+  def decode(value, _options) do
     value
-    |> deserialize(:"anytype_1", :struct, OpenapiPetstore.Model.Map.t, options)
-    |> deserialize(:"anytype_2", :struct, OpenapiPetstore.Model.Map.t, options)
-    |> deserialize(:"anytype_3", :struct, OpenapiPetstore.Model.Map.t, options)
   end
 end
 

--- a/samples/client/petstore/elixir/lib/openapi_petstore/model/array_test.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/model/array_test.ex
@@ -17,7 +17,7 @@ defmodule OpenapiPetstore.Model.ArrayTest do
   @type t :: %__MODULE__{
     :"array_of_string" => [String.t] | nil,
     :"array_array_of_integer" => [[integer()]] | nil,
-    :"array_array_of_model" => [[ReadOnlyFirst]] | nil
+    :"array_array_of_model" => [[OpenapiPetstore.Model.ReadOnlyFirst.t]] | nil
   }
 end
 

--- a/samples/client/petstore/elixir/lib/openapi_petstore/model/enum_test.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/model/enum_test.ex
@@ -21,7 +21,7 @@ defmodule OpenapiPetstore.Model.EnumTest do
     :"enum_string_required" => String.t,
     :"enum_integer" => integer() | nil,
     :"enum_number" => float() | nil,
-    :"outerEnum" => OuterEnum | nil
+    :"outerEnum" => OpenapiPetstore.Model.OuterEnum.t | nil
   }
 end
 

--- a/samples/client/petstore/elixir/lib/openapi_petstore/model/file_schema_test_class.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/model/file_schema_test_class.ex
@@ -14,8 +14,8 @@ defmodule OpenapiPetstore.Model.FileSchemaTestClass do
   ]
 
   @type t :: %__MODULE__{
-    :"file" => File | nil,
-    :"files" => [File] | nil
+    :"file" => OpenapiPetstore.Model.File.t | nil,
+    :"files" => [OpenapiPetstore.Model.File.t] | nil
   }
 end
 

--- a/samples/client/petstore/elixir/lib/openapi_petstore/model/format_test.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/model/format_test.ex
@@ -48,7 +48,6 @@ defimpl Poison.Decoder, for: OpenapiPetstore.Model.FormatTest do
   def decode(value, options) do
     value
     |> deserialize(:"date", :date, nil, options)
-    |> deserialize(:"BigDecimal", :struct, OpenapiPetstore.Model.String.t, options)
   end
 end
 

--- a/samples/client/petstore/elixir/lib/openapi_petstore/model/mixed_properties_and_additional_properties_class.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/model/mixed_properties_and_additional_properties_class.ex
@@ -17,7 +17,7 @@ defmodule OpenapiPetstore.Model.MixedPropertiesAndAdditionalPropertiesClass do
   @type t :: %__MODULE__{
     :"uuid" => String.t | nil,
     :"dateTime" => DateTime.t | nil,
-    :"map" => %{optional(String.t) => Animal} | nil
+    :"map" => %{optional(String.t) => OpenapiPetstore.Model.Animal.t} | nil
   }
 end
 

--- a/samples/client/petstore/elixir/lib/openapi_petstore/model/pet.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/model/pet.ex
@@ -19,10 +19,10 @@ defmodule OpenapiPetstore.Model.Pet do
 
   @type t :: %__MODULE__{
     :"id" => integer() | nil,
-    :"category" => Category | nil,
+    :"category" => OpenapiPetstore.Model.Category.t | nil,
     :"name" => String.t,
     :"photoUrls" => [String.t],
-    :"tags" => [Tag] | nil,
+    :"tags" => [OpenapiPetstore.Model.Tag.t] | nil,
     :"status" => String.t | nil
   }
 end


### PR DESCRIPTION
Hi @carrascoacd

This is my proposal for https://github.com/OpenAPITools/openapi-generator/pull/8159

Just let me know if this is what you expected. I used `map()` instead of `Map.t` since this is official notation according to https://hexdocs.pm/elixir/typespecs.html#basic-types